### PR TITLE
feature/ele 105 elephant index language support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.env
 /bin/
+.direnv
+.envrc

--- a/index/index.go
+++ b/index/index.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -276,10 +277,13 @@ func (idx *Indexer) loopIteration(
 			changes[item.Type] = byType
 		}
 
-		byLang, ok := byType[doc.Language]
+		// Normalize to lowercase
+		language := strings.ToLower(doc.Language)
+
+		byLang, ok := byType[language]
 		if !ok {
 			byLang = make(map[string]*enrichJob)
-			byType[doc.Language] = byLang
+			byType[language] = byLang
 		}
 
 		switch item.Event {

--- a/index/index.go
+++ b/index/index.go
@@ -363,6 +363,7 @@ func (idx *Indexer) ensureIndex(
 	ctx context.Context, indexType string, docType string, lang string,
 ) (string, error) {
 	safeDocType := nonAlphaNum.ReplaceAllString(docType, "_")
+
 	config, err := GetLanguageConfig(lang)
 	if err != nil {
 		return "", fmt.Errorf("could not get language config: %w", err)

--- a/index/index.go
+++ b/index/index.go
@@ -597,7 +597,7 @@ func (iw *indexWorker) Process(
 
 		var twErr twirp.Error
 		if errors.As(job.err, &twErr) && twErr.Code() == twirp.NotFound {
-			iw.logger.DebugCtx(ctx, "the document has been deleted, removing from index",
+			iw.logger.DebugContext(ctx, "the document has been deleted, removing from index",
 				elephantine.LogKeyDocumentUUID, job.UUID,
 				elephantine.LogKeyError, job.err)
 
@@ -608,7 +608,7 @@ func (iw *indexWorker) Process(
 				iw.contentType, iw.indexName,
 			).Inc()
 
-			iw.logger.ErrorCtx(ctx, "failed to enrich document for indexing",
+			iw.logger.ErrorContext(ctx, "failed to enrich document for indexing",
 				elephantine.LogKeyDocumentUUID, job.UUID,
 				elephantine.LogKeyError, job.err)
 
@@ -682,7 +682,7 @@ func (iw *indexWorker) Process(
 		case item.Index != nil:
 			counters["index_err"]++
 
-			iw.logger.ErrorCtx(ctx, "failed to index document",
+			iw.logger.ErrorContext(ctx, "failed to index document",
 				elephantine.LogKeyDocumentUUID, item.Index.ID,
 				elephantine.LogKeyError, item.Index.Error.String(),
 			)
@@ -693,7 +693,7 @@ func (iw *indexWorker) Process(
 
 			counters["delete_err"]++
 
-			iw.logger.ErrorCtx(ctx, "failed to delete document from index",
+			iw.logger.ErrorContext(ctx, "failed to delete document from index",
 				elephantine.LogKeyDocumentUUID, item.Index.ID,
 				elephantine.LogKeyError, item.Index.Error.String(),
 			)

--- a/index/index.go
+++ b/index/index.go
@@ -417,7 +417,7 @@ func (idx *Indexer) ensureAlias(index string, alias string) error {
 		return fmt.Errorf("could not create alias %s for index %s: %w", alias, index, err)
 	}
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("put alias status code: %w", res.Status())
+		return fmt.Errorf("put alias status code: %s", res.Status())
 	}
 
 	return nil

--- a/index/index.go
+++ b/index/index.go
@@ -374,14 +374,11 @@ func (idx *Indexer) ensureIndex(
 	}
 
 	indexTypeRoot := fmt.Sprintf("%s-%s-%s", indexType, idx.name, safeDocType)
+
 	index := fmt.Sprintf("%s-%s", indexTypeRoot, config.NameSuffix)
-
-	aliases := []string{indexTypeRoot}
-
-	// If lang is a fully qualified language-region string, we should also
-	// add a language alias for the index.
-	if lang != config.Language {
-		aliases = append(aliases, fmt.Sprintf("%s-%s", indexTypeRoot, config.Language))
+	aliases := []string{
+		indexTypeRoot,
+		fmt.Sprintf("%s-%s", indexTypeRoot, config.Language),
 	}
 
 	settings, err := json.Marshal(config.Settings)

--- a/index/index.go
+++ b/index/index.go
@@ -392,18 +392,14 @@ func (idx *Indexer) ensureIndex(
 		}
 	}
 
-	if typeAlias != "" {
-		err = idx.ensureAlias(index, typeAlias)
-		if err != nil {
-			return "", fmt.Errorf("could not ensure alias: %w", err)
-		}
+	err = idx.ensureAlias(index, typeAlias)
+	if err != nil {
+		return "", fmt.Errorf("could not ensure alias: %w", err)
 	}
 
-	if langAlias != "" {
-		err = idx.ensureAlias(index, langAlias)
-		if err != nil {
-			return "", fmt.Errorf("could not ensure alias: %w", err)
-		}
+	err = idx.ensureAlias(index, langAlias)
+	if err != nil {
+		return "", fmt.Errorf("could not ensure alias: %w", err)
 	}
 
 	return index, nil

--- a/index/index.go
+++ b/index/index.go
@@ -416,6 +416,7 @@ func (idx *Indexer) ensureAlias(index string, alias string) error {
 	if err != nil {
 		return fmt.Errorf("could not create alias %s for index %s: %w", alias, index, err)
 	}
+
 	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("put alias status code: %s", res.Status())
 	}

--- a/index/index.go
+++ b/index/index.go
@@ -362,16 +362,19 @@ func (idx *Indexer) loopIteration(
 func (idx *Indexer) ensureIndex(
 	ctx context.Context, indexType string, docType string, lang string,
 ) (string, error) {
-	settings, ok := LanguageSettings[lang]
-	if !ok {
-		settings = DefaultLanguageSetting
+	settings, err := GetIndexSettings(lang)
+	if err != nil {
+		return "", fmt.Errorf("could not get language settings: %w", err)
 	}
+	fmt.Println(settings)
 
-	alias := fmt.Sprintf("%s-%s-%s",
-		indexType, idx.name, nonAlphaNum.ReplaceAllString(docType, "_"))
-	name := fmt.Sprintf("%s-%s-%s-%s",
-		indexType, idx.name, nonAlphaNum.ReplaceAllString(docType, "_"),
-		settings.Name)
+	alias := strings.ToLower(
+		fmt.Sprintf("%s-%s-%s",
+			indexType, idx.name, nonAlphaNum.ReplaceAllString(docType, "_")))
+	name := strings.ToLower(
+		fmt.Sprintf("%s-%s-%s-%s-%s",
+			indexType, idx.name, nonAlphaNum.ReplaceAllString(docType, "_"),
+			settings.Language, settings.Name))
 
 	existRes, err := idx.client.Indices.Exists([]string{name},
 		idx.client.Indices.Exists.WithContext(ctx))

--- a/index/index.go
+++ b/index/index.go
@@ -392,14 +392,18 @@ func (idx *Indexer) ensureIndex(
 		}
 	}
 
-	err = idx.ensureAlias(index, typeAlias)
-	if err != nil {
-		return "", fmt.Errorf("could not ensure alias: %w", err)
+	if typeAlias != "" {
+		err = idx.ensureAlias(index, typeAlias)
+		if err != nil {
+			return "", fmt.Errorf("could not ensure alias: %w", err)
+		}
 	}
 
-	err = idx.ensureAlias(index, langAlias)
-	if err != nil {
-		return "", fmt.Errorf("could not ensure alias: %w", err)
+	if langAlias != "" {
+		err = idx.ensureAlias(index, langAlias)
+		if err != nil {
+			return "", fmt.Errorf("could not ensure alias: %w", err)
+		}
 	}
 
 	return index, nil
@@ -593,7 +597,7 @@ func (iw *indexWorker) Process(
 
 		var twErr twirp.Error
 		if errors.As(job.err, &twErr) && twErr.Code() == twirp.NotFound {
-			iw.logger.DebugContext(ctx, "the document has been deleted, removing from index",
+			iw.logger.DebugCtx(ctx, "the document has been deleted, removing from index",
 				elephantine.LogKeyDocumentUUID, job.UUID,
 				elephantine.LogKeyError, job.err)
 
@@ -604,7 +608,7 @@ func (iw *indexWorker) Process(
 				iw.contentType, iw.indexName,
 			).Inc()
 
-			iw.logger.ErrorContext(ctx, "failed to enrich document for indexing",
+			iw.logger.ErrorCtx(ctx, "failed to enrich document for indexing",
 				elephantine.LogKeyDocumentUUID, job.UUID,
 				elephantine.LogKeyError, job.err)
 
@@ -678,7 +682,7 @@ func (iw *indexWorker) Process(
 		case item.Index != nil:
 			counters["index_err"]++
 
-			iw.logger.ErrorContext(ctx, "failed to index document",
+			iw.logger.ErrorCtx(ctx, "failed to index document",
 				elephantine.LogKeyDocumentUUID, item.Index.ID,
 				elephantine.LogKeyError, item.Index.Error.String(),
 			)
@@ -689,7 +693,7 @@ func (iw *indexWorker) Process(
 
 			counters["delete_err"]++
 
-			iw.logger.ErrorContext(ctx, "failed to delete document from index",
+			iw.logger.ErrorCtx(ctx, "failed to delete document from index",
 				elephantine.LogKeyDocumentUUID, item.Index.ID,
 				elephantine.LogKeyError, item.Index.Error.String(),
 			)

--- a/index/index.go
+++ b/index/index.go
@@ -373,6 +373,9 @@ func (idx *Indexer) ensureIndex(
 
 	existRes, err := idx.client.Indices.Exists([]string{index},
 		idx.client.Indices.Exists.WithContext(ctx))
+
+	defer elephantine.SafeClose(idx.logger, "index exists", existRes.Body)
+
 	if err != nil {
 		return "", fmt.Errorf("check if index exists: %w", err)
 	}
@@ -385,7 +388,7 @@ func (idx *Indexer) ensureIndex(
 			return "", fmt.Errorf("create index %q: %w", index, err)
 		}
 
-		defer res.Body.Close()
+		defer elephantine.SafeClose(idx.logger, "index create", res.Body)
 
 		if res.StatusCode != http.StatusOK {
 			return "", fmt.Errorf("server response: %s", res.Status())
@@ -408,7 +411,7 @@ func (idx *Indexer) ensureIndex(
 func (idx *Indexer) ensureAlias(index string, alias string) error {
 	res, err := idx.client.Indices.PutAlias([]string{index}, alias)
 
-	defer res.Body.Close()
+	defer elephantine.SafeClose(idx.logger, "put alias", res.Body)
 
 	if err != nil {
 		return fmt.Errorf("could not create alias %s for index %s: %w", alias, index, err)

--- a/index/index.go
+++ b/index/index.go
@@ -385,12 +385,11 @@ func (idx *Indexer) ensureIndex(
 
 	existRes, err := idx.client.Indices.Exists([]string{index},
 		idx.client.Indices.Exists.WithContext(ctx))
-
-	defer elephantine.SafeClose(idx.logger, "index exists", existRes.Body)
-
 	if err != nil {
 		return "", fmt.Errorf("check if index exists: %w", err)
 	}
+
+	defer elephantine.SafeClose(idx.logger, "index exists", existRes.Body)
 
 	if existRes.StatusCode != http.StatusOK {
 		res, err := idx.client.Indices.Create(index,
@@ -422,12 +421,11 @@ func (idx *Indexer) ensureIndex(
 
 func (idx *Indexer) ensureAlias(index string, alias string) error {
 	res, err := idx.client.Indices.PutAlias([]string{index}, alias)
-
-	defer elephantine.SafeClose(idx.logger, "put alias", res.Body)
-
 	if err != nil {
 		return fmt.Errorf("could not create alias %s for index %s: %w", alias, index, err)
 	}
+
+	defer elephantine.SafeClose(idx.logger, "put alias", res.Body)
 
 	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("put alias status code: %s", res.Status())

--- a/index/index.go
+++ b/index/index.go
@@ -363,7 +363,10 @@ func (idx *Indexer) ensureIndex(
 	ctx context.Context, indexType string, docType string, lang string,
 ) (string, error) {
 	safeDocType := nonAlphaNum.ReplaceAllString(docType, "_")
-	config := GetLanguageConfig(lang)
+	config, err := GetLanguageConfig(lang)
+	if err != nil {
+		return "", fmt.Errorf("could not get language config: %w", err)
+	}
 
 	index := fmt.Sprintf("%s-%s-%s-%s", indexType, idx.name, safeDocType, config.Name)
 

--- a/index/index.go
+++ b/index/index.go
@@ -416,6 +416,9 @@ func (idx *Indexer) ensureAlias(index string, alias string) error {
 	if err != nil {
 		return fmt.Errorf("could not create alias %s for index %s: %w", alias, index, err)
 	}
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("put alias status code: %w", res.Status())
+	}
 
 	return nil
 }

--- a/index/language-settings.go
+++ b/index/language-settings.go
@@ -25,6 +25,7 @@ type OpensearchSettings struct {
 
 func GetLanguageConfig(code string) (LanguageConfig, error) {
 	code = strings.ToLower(code)
+
 	parts := strings.Split(code, "-")
 	if len(parts) < 1 || len(parts) > 2 {
 		return LanguageConfig{}, fmt.Errorf("malformed language code: %s", code)

--- a/index/language-settings.go
+++ b/index/language-settings.go
@@ -11,28 +11,29 @@ type LanguageSettings struct {
 	Settings string
 }
 
-type IndexSettings struct {
+type Settings struct {
 	Name     string
 	Language string
 	Settings string
 }
 
-func GetIndexSettings(code string) (IndexSettings, error) {
+func GetIndexSettings(code string) (Settings, error) {
 	tag, i := language.MatchStrings(languages, code)
 	if i == 0 {
-		return IndexSettings{
+		return Settings{
 			Name:     "standard",
 			Language: "",
 			Settings: "",
 		}, nil
-	} else {
-		lang, _ := tag.Base()
-		return IndexSettings{
-			Name:     strings.ToLower(code),
-			Language: lang.String(),
-			Settings: languageSettings[i].Settings,
-		}, nil
 	}
+
+	lang, _ := tag.Base()
+
+	return Settings{
+		Name:     strings.ToLower(code),
+		Language: lang.String(),
+		Settings: languageSettings[i].Settings,
+	}, nil
 }
 
 var languages = (func() language.Matcher {
@@ -40,6 +41,7 @@ var languages = (func() language.Matcher {
 	for _, lang := range languageSettings {
 		tags = append(tags, lang.Tag)
 	}
+
 	return language.NewMatcher(tags)
 })()
 

--- a/index/language-settings.go
+++ b/index/language-settings.go
@@ -1,0 +1,463 @@
+package index
+
+type LanguageSetting struct {
+	Name     string
+	Settings string
+}
+
+var DefaultLanguageSetting = LanguageSetting{
+	Name:     "standard",
+	Settings: "",
+}
+
+// These are the language-specific settings that Opensearch can handle.
+var LanguageSettings = map[string]LanguageSetting{
+	"ar": {
+		Name: "arabic",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "arabic"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"hy": {
+		Name: "armenian",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "armenian"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"eu": {
+		Name: "basque",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "basque"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"bn": {
+		Name: "bengali",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "bengali"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"bg": {
+		Name: "bulgarian",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "bulgarian"
+						}
+					}
+				}		
+			}
+		}`,
+	},
+	"ca": {
+		Name: "catalan",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "catalan"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"cs": {
+		Name: "czech",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "czech"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"da": {
+		Name: "danish",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "danish"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"nl": {
+		Name: "dutch",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "dutch"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"en": {
+		Name: "english",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "english"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"et": {
+		Name: "estonian",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "estonian"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"fi": {
+		Name: "finnish",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "finnish"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"fr": {
+		Name: "french",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "french"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"gl": {
+		Name: "galician",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "galician"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"de": {
+		Name: "german",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "german"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"el": {
+		Name: "greek",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "greek"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"hi": {
+		Name: "hindi",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "hindi"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"hu": {
+		Name: "hungarian",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "hungarian"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"ic": {
+		Name: "indonesian",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "indonesian"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"ga": {
+		Name: "irish",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "irish"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"it": {
+		Name: "italian",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "italian"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"lv": {
+		Name: "latvian",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "latvian"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"lt": {
+		Name: "lithuanian",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "lithuanian"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"no": {
+		Name: "norwegian",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "norwegian"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"fa": {
+		Name: "persian",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "persian"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"pt": {
+		Name: "portuguese",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "portuguese"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"ro": {
+		Name: "romanian",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "romanian"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"ru": {
+		Name: "russian",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "russian"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"es": {
+		Name: "spanish",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "spanish"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"sv": {
+		Name: "swedish",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "swedish"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"tr": {
+		Name: "turkish",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "turkish"
+						}
+					}
+				}
+			}
+		}`,
+	},
+	"th": {
+		Name: "thai",
+		Settings: `{
+			"settings": {
+				"analysis": {
+					"analyzer": {
+						"default": {
+							"type": "thai"
+						}
+					}
+				}
+			}
+		}`,
+	},
+}

--- a/index/language-settings.go
+++ b/index/language-settings.go
@@ -8,16 +8,28 @@ import (
 
 type LanguageSettings struct {
 	Tag      language.Tag
-	Settings string
+	Analyzer string
 }
 
-type Settings struct {
+type LanguageConfig struct {
 	Name     string
 	Language string
-	Settings string
+	Settings OpensearchSettings
 }
 
-func GetIndexSettings(code string) Settings {
+type OpensearchSettings struct {
+	Settings struct {
+		Analysis struct {
+			Analyzer struct {
+				Default struct {
+					Type string `json:"type"`
+				} `json:"default"`
+			} `json:"analyzer"`
+		} `json:"analysis"`
+	} `json:"settings"`
+}
+
+func GetLanguageConfig(code string) LanguageConfig {
 	tag, i := language.MatchStrings(languages, code)
 	if i == 0 {
 		tag = language.Make(code)
@@ -25,10 +37,13 @@ func GetIndexSettings(code string) Settings {
 
 	lang, _ := tag.Base()
 
-	return Settings{
+	s := OpensearchSettings{}
+	s.Settings.Analysis.Analyzer.Default.Type = languageSettings[i].Analyzer
+
+	return LanguageConfig{
 		Name:     strings.ToLower(code),
 		Language: lang.String(),
-		Settings: languageSettings[i].Settings,
+		Settings: s,
 	}
 }
 
@@ -45,139 +60,139 @@ var languages = (func() language.Matcher {
 var languageSettings = []LanguageSettings{
 	{
 		Tag:      language.Tag{},
-		Settings: "",
+		Analyzer: "standard",
 	},
 	{
 		Tag:      language.Arabic,
-		Settings: makeSettings("arabic"),
+		Analyzer: "arabic",
 	},
 	{
 		Tag:      language.Armenian,
-		Settings: makeSettings("armenian"),
+		Analyzer: "armenian",
 	},
 	{
 		Tag:      language.Make("eu"),
-		Settings: makeSettings("basque"),
+		Analyzer: "basque",
 	},
 	{
 		Tag:      language.Bengali,
-		Settings: makeSettings("bengali"),
+		Analyzer: "bengali",
 	},
 	{
 		Tag:      language.BrazilianPortuguese,
-		Settings: makeSettings("brazilian"),
+		Analyzer: "brazilian",
 	},
 	{
 		Tag:      language.Bulgarian,
-		Settings: makeSettings("bulgarian"),
+		Analyzer: "bulgarian",
 	},
 	{
 		Tag:      language.Catalan,
-		Settings: makeSettings("catalan"),
+		Analyzer: "catalan",
 	},
 	{
 		Tag:      language.Czech,
-		Settings: makeSettings("czech"),
+		Analyzer: "czech",
 	},
 	{
 		Tag:      language.Danish,
-		Settings: makeSettings("danish"),
+		Analyzer: "danish",
 	},
 	{
 		Tag:      language.Dutch,
-		Settings: makeSettings("dutch"),
+		Analyzer: "dutch",
 	},
 	{
 		Tag:      language.English,
-		Settings: makeSettings("english"),
+		Analyzer: "english",
 	},
 	{
 		Tag:      language.Estonian,
-		Settings: makeSettings("estonian"),
+		Analyzer: "estonian",
 	},
 	{
 		Tag:      language.Finnish,
-		Settings: makeSettings("finnish"),
+		Analyzer: "finnish",
 	},
 	{
 		Tag:      language.French,
-		Settings: makeSettings("french"),
+		Analyzer: "french",
 	},
 	{
 		Tag:      language.Make("gl"),
-		Settings: makeSettings("galician"),
+		Analyzer: "galician",
 	},
 	{
 		Tag:      language.German,
-		Settings: makeSettings("german"),
+		Analyzer: "german",
 	},
 	{
 		Tag:      language.Greek,
-		Settings: makeSettings("greek"),
+		Analyzer: "greek",
 	},
 	{
 		Tag:      language.Hindi,
-		Settings: makeSettings("hindi"),
+		Analyzer: "hindi",
 	},
 	{
 		Tag:      language.Hungarian,
-		Settings: makeSettings("hungarian"),
+		Analyzer: "hungarian",
 	},
 	{
 		Tag:      language.Indonesian,
-		Settings: makeSettings("indonesian"),
+		Analyzer: "indonesian",
 	},
 	{
 		Tag:      language.Make("ga"),
-		Settings: makeSettings("irish"),
+		Analyzer: "irish",
 	},
 	{
 		Tag:      language.Italian,
-		Settings: makeSettings("italian"),
+		Analyzer: "italian",
 	},
 	{
 		Tag:      language.Latvian,
-		Settings: makeSettings("latvian"),
+		Analyzer: "latvian",
 	},
 	{
 		Tag:      language.Lithuanian,
-		Settings: makeSettings("lithuanian"),
+		Analyzer: "lithuanian",
 	},
 	{
 		Tag:      language.Norwegian,
-		Settings: makeSettings("norwegian"),
+		Analyzer: "norwegian",
 	},
 	{
 		Tag:      language.Persian,
-		Settings: makeSettings("persian"),
+		Analyzer: "persian",
 	},
 	{
 		Tag:      language.EuropeanPortuguese,
-		Settings: makeSettings("portuguese"),
+		Analyzer: "portuguese",
 	},
 	{
 		Tag:      language.Romanian,
-		Settings: makeSettings("romanian"),
+		Analyzer: "romanian",
 	},
 	{
 		Tag:      language.Russian,
-		Settings: makeSettings("russian"),
+		Analyzer: "russian",
 	},
 	{
 		Tag:      language.Spanish,
-		Settings: makeSettings("spanish"),
+		Analyzer: "spanish",
 	},
 	{
 		Tag:      language.Swedish,
-		Settings: makeSettings("swedish"),
+		Analyzer: "swedish",
 	},
 	{
 		Tag:      language.Turkish,
-		Settings: makeSettings("turkish"),
+		Analyzer: "turkish",
 	},
 	{
 		Tag:      language.Thai,
-		Settings: makeSettings("thai"),
+		Analyzer: "thai",
 	},
 }
 

--- a/index/language-settings.go
+++ b/index/language-settings.go
@@ -28,15 +28,17 @@ func GetLanguageConfig(code string) (LanguageConfig, error) {
 	if len(parts) != 2 {
 		return LanguageConfig{}, fmt.Errorf("malformed language code: %s", code)
 	}
-	lang := parts[0]
 
+	lang := parts[0]
 	analyzer := "standard"
 
 	for _, ls := range Languages {
 		if ls.Code == code {
 			analyzer = ls.Analyzer
+
 			break
 		}
+
 		if ls.Language == lang {
 			analyzer = ls.Analyzer
 		}

--- a/index/language-settings.go
+++ b/index/language-settings.go
@@ -1,463 +1,198 @@
 package index
 
-type LanguageSetting struct {
-	Name     string
+import (
+	"strings"
+
+	"golang.org/x/text/language"
+)
+
+type LanguageSettings struct {
+	Tag      language.Tag
 	Settings string
 }
 
-var DefaultLanguageSetting = LanguageSetting{
-	Name:     "standard",
-	Settings: "",
+type IndexSettings struct {
+	Name     string
+	Language string
+	Settings string
 }
 
+func GetIndexSettings(code string) (IndexSettings, error) {
+	tag, i := language.MatchStrings(languages, code)
+	if i == 0 {
+		return IndexSettings{
+			Name:     "standard",
+			Language: "",
+			Settings: "",
+		}, nil
+	} else {
+		lang, _ := tag.Base()
+		return IndexSettings{
+			Name:     strings.ToLower(code),
+			Language: lang.String(),
+			Settings: languageSettings[i].Settings,
+		}, nil
+	}
+}
+
+var languages = (func() language.Matcher {
+	tags := []language.Tag{}
+	for _, lang := range languageSettings {
+		tags = append(tags, lang.Tag)
+	}
+	return language.NewMatcher(tags)
+})()
+
 // These are the language-specific settings that Opensearch can handle.
-var LanguageSettings = map[string]LanguageSetting{
-	"ar": {
-		Name: "arabic",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "arabic"
-						}
+var languageSettings = []LanguageSettings{
+	{
+		Tag:      language.Tag{},
+		Settings: "",
+	},
+	{
+		Tag:      language.Arabic,
+		Settings: makeSettings("arabic"),
+	},
+	{
+		Tag:      language.Armenian,
+		Settings: makeSettings("armenian"),
+	},
+	{
+		Tag:      language.Make("eu"),
+		Settings: makeSettings("basque"),
+	},
+	{
+		Tag:      language.Bengali,
+		Settings: makeSettings("bengali"),
+	},
+	{
+		Tag:      language.BrazilianPortuguese,
+		Settings: makeSettings("brazilian"),
+	},
+	{
+		Tag:      language.Bulgarian,
+		Settings: makeSettings("bulgarian"),
+	},
+	{
+		Tag:      language.Catalan,
+		Settings: makeSettings("catalan"),
+	},
+	{
+		Tag:      language.Czech,
+		Settings: makeSettings("czech"),
+	},
+	{
+		Tag:      language.Danish,
+		Settings: makeSettings("danish"),
+	},
+	{
+		Tag:      language.Dutch,
+		Settings: makeSettings("dutch"),
+	},
+	{
+		Tag:      language.English,
+		Settings: makeSettings("english"),
+	},
+	{
+		Tag:      language.Estonian,
+		Settings: makeSettings("estonian"),
+	},
+	{
+		Tag:      language.Finnish,
+		Settings: makeSettings("finnish"),
+	},
+	{
+		Tag:      language.French,
+		Settings: makeSettings("french"),
+	},
+	{
+		Tag:      language.Make("gl"),
+		Settings: makeSettings("galician"),
+	},
+	{
+		Tag:      language.German,
+		Settings: makeSettings("german"),
+	},
+	{
+		Tag:      language.Greek,
+		Settings: makeSettings("greek"),
+	},
+	{
+		Tag:      language.Hindi,
+		Settings: makeSettings("hindi"),
+	},
+	{
+		Tag:      language.Hungarian,
+		Settings: makeSettings("hungarian"),
+	},
+	{
+		Tag:      language.Indonesian,
+		Settings: makeSettings("indonesian"),
+	},
+	{
+		Tag:      language.Make("ga"),
+		Settings: makeSettings("irish"),
+	},
+	{
+		Tag:      language.Italian,
+		Settings: makeSettings("italian"),
+	},
+	{
+		Tag:      language.Latvian,
+		Settings: makeSettings("latvian"),
+	},
+	{
+		Tag:      language.Lithuanian,
+		Settings: makeSettings("lithuanian"),
+	},
+	{
+		Tag:      language.Norwegian,
+		Settings: makeSettings("norwegian"),
+	},
+	{
+		Tag:      language.Persian,
+		Settings: makeSettings("persian"),
+	},
+	{
+		Tag:      language.EuropeanPortuguese,
+		Settings: makeSettings("portuguese"),
+	},
+	{
+		Tag:      language.Romanian,
+		Settings: makeSettings("romanian"),
+	},
+	{
+		Tag:      language.Russian,
+		Settings: makeSettings("russian"),
+	},
+	{
+		Tag:      language.Spanish,
+		Settings: makeSettings("spanish"),
+	},
+	{
+		Tag:      language.Swedish,
+		Settings: makeSettings("swedish"),
+	},
+	{
+		Tag:      language.Turkish,
+		Settings: makeSettings("turkish"),
+	},
+	{
+		Tag:      language.Thai,
+		Settings: makeSettings("thai"),
+	},
+}
+
+func makeSettings(analyzer string) string {
+	return `{
+		"settings": {
+			"analysis": {
+				"analyzer": {
+					"default": {
+						"type": "` + analyzer + `"
 					}
 				}
 			}
-		}`,
-	},
-	"hy": {
-		Name: "armenian",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "armenian"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"eu": {
-		Name: "basque",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "basque"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"bn": {
-		Name: "bengali",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "bengali"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"bg": {
-		Name: "bulgarian",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "bulgarian"
-						}
-					}
-				}		
-			}
-		}`,
-	},
-	"ca": {
-		Name: "catalan",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "catalan"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"cs": {
-		Name: "czech",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "czech"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"da": {
-		Name: "danish",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "danish"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"nl": {
-		Name: "dutch",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "dutch"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"en": {
-		Name: "english",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "english"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"et": {
-		Name: "estonian",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "estonian"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"fi": {
-		Name: "finnish",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "finnish"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"fr": {
-		Name: "french",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "french"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"gl": {
-		Name: "galician",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "galician"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"de": {
-		Name: "german",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "german"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"el": {
-		Name: "greek",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "greek"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"hi": {
-		Name: "hindi",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "hindi"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"hu": {
-		Name: "hungarian",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "hungarian"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"ic": {
-		Name: "indonesian",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "indonesian"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"ga": {
-		Name: "irish",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "irish"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"it": {
-		Name: "italian",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "italian"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"lv": {
-		Name: "latvian",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "latvian"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"lt": {
-		Name: "lithuanian",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "lithuanian"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"no": {
-		Name: "norwegian",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "norwegian"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"fa": {
-		Name: "persian",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "persian"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"pt": {
-		Name: "portuguese",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "portuguese"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"ro": {
-		Name: "romanian",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "romanian"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"ru": {
-		Name: "russian",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "russian"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"es": {
-		Name: "spanish",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "spanish"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"sv": {
-		Name: "swedish",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "swedish"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"tr": {
-		Name: "turkish",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "turkish"
-						}
-					}
-				}
-			}
-		}`,
-	},
-	"th": {
-		Name: "thai",
-		Settings: `{
-			"settings": {
-				"analysis": {
-					"analyzer": {
-						"default": {
-							"type": "thai"
-						}
-					}
-				}
-			}
-		}`,
-	},
+		}
+	}`
 }

--- a/index/language-settings.go
+++ b/index/language-settings.go
@@ -17,14 +17,14 @@ type Settings struct {
 	Settings string
 }
 
-func GetIndexSettings(code string) (Settings, error) {
+func GetIndexSettings(code string) Settings {
 	tag, i := language.MatchStrings(languages, code)
 	if i == 0 {
 		return Settings{
 			Name:     "standard",
 			Language: "",
 			Settings: "",
-		}, nil
+		}
 	}
 
 	lang, _ := tag.Base()
@@ -33,7 +33,7 @@ func GetIndexSettings(code string) (Settings, error) {
 		Name:     strings.ToLower(code),
 		Language: lang.String(),
 		Settings: languageSettings[i].Settings,
-	}, nil
+	}
 }
 
 var languages = (func() language.Matcher {

--- a/index/language-settings.go
+++ b/index/language-settings.go
@@ -26,7 +26,7 @@ type OpensearchSettings struct {
 func GetLanguageConfig(code string) (LanguageConfig, error) {
 	code = strings.ToLower(code)
 	parts := strings.Split(code, "-")
-	if len(parts) != 2 {
+	if len(parts) < 1 || len(parts) > 2 {
 		return LanguageConfig{}, fmt.Errorf("malformed language code: %s", code)
 	}
 
@@ -61,7 +61,14 @@ type Language struct {
 	Analyzer string
 }
 
+// Order matters; the matching algorithm will pick the first exact Code match,
+// or failing that, the last Language match.
 var languages = []Language{
+	// Portuguese is a special case since it can be either european or brazilian
+	// depending on the region. This line makes european the default if no
+	// region was given.
+	{Code: "pt", Language: "pt", Analyzer: "portuguese"},
+
 	{Code: "ar-eg", Language: "ar", Analyzer: "arabic"},
 	{Code: "hy-am", Language: "hy", Analyzer: "armenian"},
 	{Code: "eu-es", Language: "eu", Analyzer: "basque"},

--- a/index/language-settings.go
+++ b/index/language-settings.go
@@ -20,11 +20,7 @@ type Settings struct {
 func GetIndexSettings(code string) Settings {
 	tag, i := language.MatchStrings(languages, code)
 	if i == 0 {
-		return Settings{
-			Name:     "standard",
-			Language: "",
-			Settings: "",
-		}
+		tag = language.Make(code)
 	}
 
 	lang, _ := tag.Base()

--- a/index/language-settings.go
+++ b/index/language-settings.go
@@ -1,15 +1,9 @@
 package index
 
 import (
+	"fmt"
 	"strings"
-
-	"golang.org/x/text/language"
 )
-
-type LanguageSettings struct {
-	Tag      language.Tag
-	Analyzer string
-}
 
 type LanguageConfig struct {
 	Name     string
@@ -29,183 +23,73 @@ type OpensearchSettings struct {
 	} `json:"settings"`
 }
 
-func GetLanguageConfig(code string) LanguageConfig {
-	tag, i := language.MatchStrings(languages, code)
-	if i == 0 {
-		tag = language.Make(code)
+func GetLanguageConfig(code string) (LanguageConfig, error) {
+	parts := strings.Split(code, "-")
+	if len(parts) != 2 {
+		return LanguageConfig{}, fmt.Errorf("malformed language code: %s", code)
+	}
+	lang := parts[0]
+
+	analyzer := "standard"
+
+	for _, ls := range Languages {
+		if ls.Code == code {
+			analyzer = ls.Analyzer
+			break
+		}
+		if ls.Language == lang {
+			analyzer = ls.Analyzer
+		}
 	}
 
-	lang, _ := tag.Base()
-
 	s := OpensearchSettings{}
-	s.Settings.Analysis.Analyzer.Default.Type = languageSettings[i].Analyzer
+	s.Settings.Analysis.Analyzer.Default.Type = analyzer
 
 	return LanguageConfig{
 		Name:     strings.ToLower(code),
-		Language: lang.String(),
+		Language: lang,
 		Settings: s,
-	}
+	}, nil
 }
 
-var languages = (func() language.Matcher {
-	tags := []language.Tag{}
-	for _, lang := range languageSettings {
-		tags = append(tags, lang.Tag)
-	}
-
-	return language.NewMatcher(tags)
-})()
-
-// These are the language-specific settings that Opensearch can handle.
-var languageSettings = []LanguageSettings{
-	{
-		Tag:      language.Tag{},
-		Analyzer: "standard",
-	},
-	{
-		Tag:      language.Arabic,
-		Analyzer: "arabic",
-	},
-	{
-		Tag:      language.Armenian,
-		Analyzer: "armenian",
-	},
-	{
-		Tag:      language.Make("eu"),
-		Analyzer: "basque",
-	},
-	{
-		Tag:      language.Bengali,
-		Analyzer: "bengali",
-	},
-	{
-		Tag:      language.BrazilianPortuguese,
-		Analyzer: "brazilian",
-	},
-	{
-		Tag:      language.Bulgarian,
-		Analyzer: "bulgarian",
-	},
-	{
-		Tag:      language.Catalan,
-		Analyzer: "catalan",
-	},
-	{
-		Tag:      language.Czech,
-		Analyzer: "czech",
-	},
-	{
-		Tag:      language.Danish,
-		Analyzer: "danish",
-	},
-	{
-		Tag:      language.Dutch,
-		Analyzer: "dutch",
-	},
-	{
-		Tag:      language.English,
-		Analyzer: "english",
-	},
-	{
-		Tag:      language.Estonian,
-		Analyzer: "estonian",
-	},
-	{
-		Tag:      language.Finnish,
-		Analyzer: "finnish",
-	},
-	{
-		Tag:      language.French,
-		Analyzer: "french",
-	},
-	{
-		Tag:      language.Make("gl"),
-		Analyzer: "galician",
-	},
-	{
-		Tag:      language.German,
-		Analyzer: "german",
-	},
-	{
-		Tag:      language.Greek,
-		Analyzer: "greek",
-	},
-	{
-		Tag:      language.Hindi,
-		Analyzer: "hindi",
-	},
-	{
-		Tag:      language.Hungarian,
-		Analyzer: "hungarian",
-	},
-	{
-		Tag:      language.Indonesian,
-		Analyzer: "indonesian",
-	},
-	{
-		Tag:      language.Make("ga"),
-		Analyzer: "irish",
-	},
-	{
-		Tag:      language.Italian,
-		Analyzer: "italian",
-	},
-	{
-		Tag:      language.Latvian,
-		Analyzer: "latvian",
-	},
-	{
-		Tag:      language.Lithuanian,
-		Analyzer: "lithuanian",
-	},
-	{
-		Tag:      language.Norwegian,
-		Analyzer: "norwegian",
-	},
-	{
-		Tag:      language.Persian,
-		Analyzer: "persian",
-	},
-	{
-		Tag:      language.EuropeanPortuguese,
-		Analyzer: "portuguese",
-	},
-	{
-		Tag:      language.Romanian,
-		Analyzer: "romanian",
-	},
-	{
-		Tag:      language.Russian,
-		Analyzer: "russian",
-	},
-	{
-		Tag:      language.Spanish,
-		Analyzer: "spanish",
-	},
-	{
-		Tag:      language.Swedish,
-		Analyzer: "swedish",
-	},
-	{
-		Tag:      language.Turkish,
-		Analyzer: "turkish",
-	},
-	{
-		Tag:      language.Thai,
-		Analyzer: "thai",
-	},
+type Language struct {
+	Code     string
+	Language string
+	Analyzer string
 }
 
-func makeSettings(analyzer string) string {
-	return `{
-		"settings": {
-			"analysis": {
-				"analyzer": {
-					"default": {
-						"type": "` + analyzer + `"
-					}
-				}
-			}
-		}
-	}`
+var Languages = []Language{
+	{Code: "ar-EG", Language: "ar", Analyzer: "arabic"},
+	{Code: "hy-AM", Language: "hy", Analyzer: "armenian"},
+	{Code: "eu-ES", Language: "eu", Analyzer: "basque"},
+	{Code: "bn-BD", Language: "bn", Analyzer: "bengali"},
+	{Code: "pt-BR", Language: "pt", Analyzer: "brazilian"},
+	{Code: "bg-BG", Language: "bg", Analyzer: "bulgarian"},
+	{Code: "ca-ES", Language: "ca", Analyzer: "catalan"},
+	{Code: "cs-CZ", Language: "cs", Analyzer: "czech"},
+	{Code: "da-DK", Language: "da", Analyzer: "danish"},
+	{Code: "nl-NL", Language: "nl", Analyzer: "dutch"},
+	{Code: "en-US", Language: "en", Analyzer: "english"},
+	{Code: "et-EE", Language: "et", Analyzer: "estonian"},
+	{Code: "fi-FI", Language: "fi", Analyzer: "finnish"},
+	{Code: "fr-FR", Language: "fr", Analyzer: "french"},
+	{Code: "gl-ES", Language: "gl", Analyzer: "galician"},
+	{Code: "de-DE", Language: "de", Analyzer: "german"},
+	{Code: "el-GR", Language: "el", Analyzer: "greek"},
+	{Code: "hi-IN", Language: "hi", Analyzer: "hindi"},
+	{Code: "hu-HU", Language: "hu", Analyzer: "hungarian"},
+	{Code: "id-ID", Language: "id", Analyzer: "indonesian"},
+	{Code: "ga-IE", Language: "ga", Analyzer: "irish"},
+	{Code: "it-IT", Language: "it", Analyzer: "italian"},
+	{Code: "lv-LV", Language: "lv", Analyzer: "latvian"},
+	{Code: "lt-LT", Language: "lt", Analyzer: "lithuanian"},
+	{Code: "no-NO", Language: "no", Analyzer: "norwegian"},
+	{Code: "fa-IR", Language: "fa", Analyzer: "persian"},
+	{Code: "pt-PT", Language: "pt", Analyzer: "portuguese"},
+	{Code: "ro-RO", Language: "ro", Analyzer: "romanian"},
+	{Code: "ru-RU", Language: "ru", Analyzer: "russian"},
+	{Code: "es-ES", Language: "es", Analyzer: "spanish"},
+	{Code: "sv-SE", Language: "sv", Analyzer: "swedish"},
+	{Code: "tr-TR", Language: "tr", Analyzer: "turkish"},
+	{Code: "th-TH", Language: "th", Analyzer: "thai"},
 }

--- a/index/language-settings.go
+++ b/index/language-settings.go
@@ -32,7 +32,7 @@ func GetLanguageConfig(code string) (LanguageConfig, error) {
 	lang := parts[0]
 	analyzer := "standard"
 
-	for _, ls := range Languages {
+	for _, ls := range languages {
 		if ls.Code == code {
 			analyzer = ls.Analyzer
 
@@ -60,7 +60,7 @@ type Language struct {
 	Analyzer string
 }
 
-var Languages = []Language{
+var languages = []Language{
 	{Code: "ar-EG", Language: "ar", Analyzer: "arabic"},
 	{Code: "hy-AM", Language: "hy", Analyzer: "armenian"},
 	{Code: "eu-ES", Language: "eu", Analyzer: "basque"},

--- a/index/language-settings.go
+++ b/index/language-settings.go
@@ -24,6 +24,7 @@ type OpensearchSettings struct {
 }
 
 func GetLanguageConfig(code string) (LanguageConfig, error) {
+	code = strings.ToLower(code)
 	parts := strings.Split(code, "-")
 	if len(parts) != 2 {
 		return LanguageConfig{}, fmt.Errorf("malformed language code: %s", code)
@@ -48,7 +49,7 @@ func GetLanguageConfig(code string) (LanguageConfig, error) {
 	s.Settings.Analysis.Analyzer.Default.Type = analyzer
 
 	return LanguageConfig{
-		Name:     strings.ToLower(code),
+		Name:     code,
 		Language: lang,
 		Settings: s,
 	}, nil
@@ -61,37 +62,37 @@ type Language struct {
 }
 
 var languages = []Language{
-	{Code: "ar-EG", Language: "ar", Analyzer: "arabic"},
-	{Code: "hy-AM", Language: "hy", Analyzer: "armenian"},
-	{Code: "eu-ES", Language: "eu", Analyzer: "basque"},
-	{Code: "bn-BD", Language: "bn", Analyzer: "bengali"},
-	{Code: "pt-BR", Language: "pt", Analyzer: "brazilian"},
-	{Code: "bg-BG", Language: "bg", Analyzer: "bulgarian"},
-	{Code: "ca-ES", Language: "ca", Analyzer: "catalan"},
-	{Code: "cs-CZ", Language: "cs", Analyzer: "czech"},
-	{Code: "da-DK", Language: "da", Analyzer: "danish"},
-	{Code: "nl-NL", Language: "nl", Analyzer: "dutch"},
-	{Code: "en-US", Language: "en", Analyzer: "english"},
-	{Code: "et-EE", Language: "et", Analyzer: "estonian"},
-	{Code: "fi-FI", Language: "fi", Analyzer: "finnish"},
-	{Code: "fr-FR", Language: "fr", Analyzer: "french"},
-	{Code: "gl-ES", Language: "gl", Analyzer: "galician"},
-	{Code: "de-DE", Language: "de", Analyzer: "german"},
-	{Code: "el-GR", Language: "el", Analyzer: "greek"},
-	{Code: "hi-IN", Language: "hi", Analyzer: "hindi"},
-	{Code: "hu-HU", Language: "hu", Analyzer: "hungarian"},
-	{Code: "id-ID", Language: "id", Analyzer: "indonesian"},
-	{Code: "ga-IE", Language: "ga", Analyzer: "irish"},
-	{Code: "it-IT", Language: "it", Analyzer: "italian"},
-	{Code: "lv-LV", Language: "lv", Analyzer: "latvian"},
-	{Code: "lt-LT", Language: "lt", Analyzer: "lithuanian"},
-	{Code: "no-NO", Language: "no", Analyzer: "norwegian"},
-	{Code: "fa-IR", Language: "fa", Analyzer: "persian"},
-	{Code: "pt-PT", Language: "pt", Analyzer: "portuguese"},
-	{Code: "ro-RO", Language: "ro", Analyzer: "romanian"},
-	{Code: "ru-RU", Language: "ru", Analyzer: "russian"},
-	{Code: "es-ES", Language: "es", Analyzer: "spanish"},
-	{Code: "sv-SE", Language: "sv", Analyzer: "swedish"},
-	{Code: "tr-TR", Language: "tr", Analyzer: "turkish"},
-	{Code: "th-TH", Language: "th", Analyzer: "thai"},
+	{Code: "ar-eg", Language: "ar", Analyzer: "arabic"},
+	{Code: "hy-am", Language: "hy", Analyzer: "armenian"},
+	{Code: "eu-es", Language: "eu", Analyzer: "basque"},
+	{Code: "bn-bd", Language: "bn", Analyzer: "bengali"},
+	{Code: "pt-br", Language: "pt", Analyzer: "brazilian"},
+	{Code: "bg-bg", Language: "bg", Analyzer: "bulgarian"},
+	{Code: "ca-es", Language: "ca", Analyzer: "catalan"},
+	{Code: "cs-cz", Language: "cs", Analyzer: "czech"},
+	{Code: "da-dk", Language: "da", Analyzer: "danish"},
+	{Code: "nl-nl", Language: "nl", Analyzer: "dutch"},
+	{Code: "en-us", Language: "en", Analyzer: "english"},
+	{Code: "et-ee", Language: "et", Analyzer: "estonian"},
+	{Code: "fi-fi", Language: "fi", Analyzer: "finnish"},
+	{Code: "fr-fr", Language: "fr", Analyzer: "french"},
+	{Code: "gl-es", Language: "gl", Analyzer: "galician"},
+	{Code: "de-de", Language: "de", Analyzer: "german"},
+	{Code: "el-gr", Language: "el", Analyzer: "greek"},
+	{Code: "hi-in", Language: "hi", Analyzer: "hindi"},
+	{Code: "hu-hu", Language: "hu", Analyzer: "hungarian"},
+	{Code: "id-id", Language: "id", Analyzer: "indonesian"},
+	{Code: "ga-ie", Language: "ga", Analyzer: "irish"},
+	{Code: "it-it", Language: "it", Analyzer: "italian"},
+	{Code: "lv-lv", Language: "lv", Analyzer: "latvian"},
+	{Code: "lt-lt", Language: "lt", Analyzer: "lithuanian"},
+	{Code: "no-no", Language: "no", Analyzer: "norwegian"},
+	{Code: "fa-ir", Language: "fa", Analyzer: "persian"},
+	{Code: "pt-pt", Language: "pt", Analyzer: "portuguese"},
+	{Code: "ro-ro", Language: "ro", Analyzer: "romanian"},
+	{Code: "ru-ru", Language: "ru", Analyzer: "russian"},
+	{Code: "es-es", Language: "es", Analyzer: "spanish"},
+	{Code: "sv-se", Language: "sv", Analyzer: "swedish"},
+	{Code: "tr-tr", Language: "tr", Analyzer: "turkish"},
+	{Code: "th-th", Language: "th", Analyzer: "thai"},
 }

--- a/index/language-settings.go
+++ b/index/language-settings.go
@@ -6,9 +6,9 @@ import (
 )
 
 type LanguageConfig struct {
-	Name     string
-	Language string
-	Settings OpensearchSettings
+	NameSuffix string
+	Language   string
+	Settings   OpensearchSettings
 }
 
 type OpensearchSettings struct {
@@ -31,6 +31,12 @@ func GetLanguageConfig(code string) (LanguageConfig, error) {
 	}
 
 	lang := parts[0]
+
+	region := "unspecified"
+	if len(parts) > 1 {
+		region = parts[1]
+	}
+
 	analyzer := "standard"
 
 	for _, ls := range languages {
@@ -49,9 +55,9 @@ func GetLanguageConfig(code string) (LanguageConfig, error) {
 	s.Settings.Analysis.Analyzer.Default.Type = analyzer
 
 	return LanguageConfig{
-		Name:     code,
-		Language: lang,
-		Settings: s,
+		NameSuffix: fmt.Sprintf("%s-%s", lang, region),
+		Language:   lang,
+		Settings:   s,
 	}, nil
 }
 

--- a/index/language-settings_test.go
+++ b/index/language-settings_test.go
@@ -20,13 +20,12 @@ var params = []expectation{
 	{code: "pt-PT", name: "pt-pt", language: "pt", analyzer: "portuguese"},
 	{code: "en-US", name: "en-us", language: "en", analyzer: "english"},
 	{code: "en-NZ", name: "en-nz", language: "en", analyzer: "english"},
-	{code: "az-AZ", name: "az-az", language: "ru", analyzer: "russian"},
 	{code: "ja-JP", name: "ja-jp", language: "ja", analyzer: "standard"},
 }
 
 func TestGetLanguageSetting(t *testing.T) {
 	for i := range params {
-		s := index.GetLanguageConfig(params[i].code)
+		s, _ := index.GetLanguageConfig(params[i].code)
 
 		if s.Name != params[i].name {
 			t.Fatalf("expected Name: %q, got %q", params[i].name, s.Name)

--- a/index/language-settings_test.go
+++ b/index/language-settings_test.go
@@ -18,23 +18,23 @@ var params = []expectation{
 	{code: "sv-se", name: "sv-se", language: "sv", analyzer: "swedish"},
 	{code: "sv-FI", name: "sv-fi", language: "sv", analyzer: "swedish"},
 	{code: "sv-fi", name: "sv-fi", language: "sv", analyzer: "swedish"},
-	{code: "sv", name: "sv", language: "sv", analyzer: "swedish"},
+	{code: "sv", name: "sv-unspecified", language: "sv", analyzer: "swedish"},
 	{code: "pt-BR", name: "pt-br", language: "pt", analyzer: "brazilian"},
 	{code: "pt-br", name: "pt-br", language: "pt", analyzer: "brazilian"},
 	{code: "pt-PT", name: "pt-pt", language: "pt", analyzer: "portuguese"},
 	{code: "pt-pt", name: "pt-pt", language: "pt", analyzer: "portuguese"},
-	{code: "pt", name: "pt", language: "pt", analyzer: "portuguese"},
+	{code: "pt", name: "pt-unspecified", language: "pt", analyzer: "portuguese"},
 	{code: "ja-JP", name: "ja-jp", language: "ja", analyzer: "standard"},
 	{code: "ja-jp", name: "ja-jp", language: "ja", analyzer: "standard"},
-	{code: "ja", name: "ja", language: "ja", analyzer: "standard"},
+	{code: "ja", name: "ja-unspecified", language: "ja", analyzer: "standard"},
 }
 
 func TestGetLanguageSetting(t *testing.T) {
 	for _, param := range params {
 		s, _ := index.GetLanguageConfig(param.code)
 
-		if s.Name != param.name {
-			t.Fatalf("%s: expected Name: %q, got %q", param.code, param.name, s.Name)
+		if s.NameSuffix != param.name {
+			t.Fatalf("%s: expected Name: %q, got %q", param.code, param.name, s.NameSuffix)
 		}
 
 		if s.Language != param.language {

--- a/index/language-settings_test.go
+++ b/index/language-settings_test.go
@@ -21,8 +21,8 @@ var params = []expectation{
 	{code: "pt-PT", name: "pt-pt", language: "pt", analyzer: "portuguese"},
 	{code: "en-US", name: "en-us", language: "en", analyzer: "english"},
 	{code: "en-NZ", name: "en-nz", language: "en", analyzer: "english"},
-	{code: "az", name: "az", language: "ru", analyzer: "russian"},
-	{code: "jp", name: "standard", language: "", analyzer: ""},
+	{code: "az-AZ", name: "az-az", language: "ru", analyzer: "russian"},
+	{code: "ja-JP", name: "ja-jp", language: "ja", analyzer: ""},
 }
 
 func TestGetLanguageSetting(t *testing.T) {

--- a/index/language-settings_test.go
+++ b/index/language-settings_test.go
@@ -27,7 +27,7 @@ var params = []expectation{
 
 func TestGetLanguageSetting(t *testing.T) {
 	for i := range params {
-		s, _ := index.GetIndexSettings(params[i].code)
+		s := index.GetIndexSettings(params[i].code)
 
 		if s.Name != params[i].name {
 			t.Fatalf("expected Name: %q, got %q", params[i].name, s.Name)

--- a/index/language-settings_test.go
+++ b/index/language-settings_test.go
@@ -15,29 +15,32 @@ type expectation struct {
 
 var params = []expectation{
 	{code: "sv-SE", name: "sv-se", language: "sv", analyzer: "swedish"},
+	{code: "sv-se", name: "sv-se", language: "sv", analyzer: "swedish"},
 	{code: "sv-FI", name: "sv-fi", language: "sv", analyzer: "swedish"},
+	{code: "sv-fi", name: "sv-fi", language: "sv", analyzer: "swedish"},
 	{code: "pt-BR", name: "pt-br", language: "pt", analyzer: "brazilian"},
+	{code: "pt-br", name: "pt-br", language: "pt", analyzer: "brazilian"},
 	{code: "pt-PT", name: "pt-pt", language: "pt", analyzer: "portuguese"},
-	{code: "en-US", name: "en-us", language: "en", analyzer: "english"},
-	{code: "en-NZ", name: "en-nz", language: "en", analyzer: "english"},
+	{code: "pt-pt", name: "pt-pt", language: "pt", analyzer: "portuguese"},
 	{code: "ja-JP", name: "ja-jp", language: "ja", analyzer: "standard"},
+	{code: "ja-jp", name: "ja-jp", language: "ja", analyzer: "standard"},
 }
 
 func TestGetLanguageSetting(t *testing.T) {
-	for i := range params {
-		s, _ := index.GetLanguageConfig(params[i].code)
+	for _, param := range params {
+		s, _ := index.GetLanguageConfig(param.code)
 
-		if s.Name != params[i].name {
-			t.Fatalf("expected Name: %q, got %q", params[i].name, s.Name)
+		if s.Name != param.name {
+			t.Fatalf("%s: expected Name: %q, got %q", param.code, param.name, s.Name)
 		}
 
-		if s.Language != params[i].language {
-			t.Fatalf("expected Language: %q, got %q", params[i].language, s.Language)
+		if s.Language != param.language {
+			t.Fatalf("%s: expected Language: %q, got %q", param.code, param.language, s.Language)
 		}
 
-		if s.Settings.Settings.Analysis.Analyzer.Default.Type != params[i].analyzer {
-			t.Fatalf("expected settings default Analyzer: %q, got %q",
-				params[i].analyzer,
+		if s.Settings.Settings.Analysis.Analyzer.Default.Type != param.analyzer {
+			t.Fatalf("%s: expected settings default Analyzer: %q, got %q", param.code,
+				param.analyzer,
 				s.Settings.Settings.Analysis.Analyzer.Default.Type)
 		}
 	}

--- a/index/language-settings_test.go
+++ b/index/language-settings_test.go
@@ -21,12 +21,12 @@ var params = []expectation{
 	{code: "en-US", name: "en-us", language: "en", analyzer: "english"},
 	{code: "en-NZ", name: "en-nz", language: "en", analyzer: "english"},
 	{code: "az-AZ", name: "az-az", language: "ru", analyzer: "russian"},
-	{code: "ja-JP", name: "ja-jp", language: "ja", analyzer: ""},
+	{code: "ja-JP", name: "ja-jp", language: "ja", analyzer: "standard"},
 }
 
 func TestGetLanguageSetting(t *testing.T) {
 	for i := range params {
-		s := index.GetIndexSettings(params[i].code)
+		s := index.GetLanguageConfig(params[i].code)
 
 		if s.Name != params[i].name {
 			t.Fatalf("expected Name: %q, got %q", params[i].name, s.Name)
@@ -37,7 +37,9 @@ func TestGetLanguageSetting(t *testing.T) {
 		}
 
 		if s.Settings.Settings.Analysis.Analyzer.Default.Type != params[i].analyzer {
-			t.Fatalf("expected settings default Analyzer: %q, got %q", params[i].analyzer, s.Settings)
+			t.Fatalf("expected settings default Analyzer: %q, got %q",
+				params[i].analyzer,
+				s.Settings.Settings.Analysis.Analyzer.Default.Type)
 		}
 	}
 }

--- a/index/language-settings_test.go
+++ b/index/language-settings_test.go
@@ -1,0 +1,42 @@
+package index_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ttab/elephant-index/index"
+)
+
+type expectation struct {
+	code     string
+	name     string
+	language string
+	analyzer string
+}
+
+var params = []expectation{
+	{code: "sv-SE", name: "sv-se", language: "sv", analyzer: "swedish"},
+	{code: "sv-FI", name: "sv-fi", language: "sv", analyzer: "swedish"},
+	{code: "pt-BR", name: "pt-br", language: "pt", analyzer: "brazilian"},
+	{code: "pt-PT", name: "pt-pt", language: "pt", analyzer: "portuguese"},
+	{code: "en-US", name: "en-us", language: "en", analyzer: "english"},
+	{code: "en-NZ", name: "en-nz", language: "en", analyzer: "english"},
+	{code: "az", name: "az", language: "ru", analyzer: "russian"},
+	{code: "jp", name: "standard", language: "", analyzer: ""},
+}
+
+func TestGetLanguageSetting(t *testing.T) {
+	for i := range params {
+		s, _ := index.GetIndexSettings(params[i].code)
+		if s.Name != params[i].name {
+			t.Fatalf("expected Name: %q, got %q", params[i].name, s.Name)
+		}
+		if s.Language != params[i].language {
+			t.Fatalf("expected Language: %q, got %q", params[i].language, s.Language)
+		}
+		if !strings.Contains(s.Settings, params[i].analyzer) {
+			t.Fatalf("expected settings default Analyzer: %q, got %q", params[i].analyzer, s.Settings)
+		}
+	}
+
+}

--- a/index/language-settings_test.go
+++ b/index/language-settings_test.go
@@ -28,15 +28,17 @@ var params = []expectation{
 func TestGetLanguageSetting(t *testing.T) {
 	for i := range params {
 		s, _ := index.GetIndexSettings(params[i].code)
+
 		if s.Name != params[i].name {
 			t.Fatalf("expected Name: %q, got %q", params[i].name, s.Name)
 		}
+
 		if s.Language != params[i].language {
 			t.Fatalf("expected Language: %q, got %q", params[i].language, s.Language)
 		}
+
 		if !strings.Contains(s.Settings, params[i].analyzer) {
 			t.Fatalf("expected settings default Analyzer: %q, got %q", params[i].analyzer, s.Settings)
 		}
 	}
-
 }

--- a/index/language-settings_test.go
+++ b/index/language-settings_test.go
@@ -18,12 +18,15 @@ var params = []expectation{
 	{code: "sv-se", name: "sv-se", language: "sv", analyzer: "swedish"},
 	{code: "sv-FI", name: "sv-fi", language: "sv", analyzer: "swedish"},
 	{code: "sv-fi", name: "sv-fi", language: "sv", analyzer: "swedish"},
+	{code: "sv", name: "sv", language: "sv", analyzer: "swedish"},
 	{code: "pt-BR", name: "pt-br", language: "pt", analyzer: "brazilian"},
 	{code: "pt-br", name: "pt-br", language: "pt", analyzer: "brazilian"},
 	{code: "pt-PT", name: "pt-pt", language: "pt", analyzer: "portuguese"},
 	{code: "pt-pt", name: "pt-pt", language: "pt", analyzer: "portuguese"},
+	{code: "pt", name: "pt", language: "pt", analyzer: "portuguese"},
 	{code: "ja-JP", name: "ja-jp", language: "ja", analyzer: "standard"},
 	{code: "ja-jp", name: "ja-jp", language: "ja", analyzer: "standard"},
+	{code: "ja", name: "ja", language: "ja", analyzer: "standard"},
 }
 
 func TestGetLanguageSetting(t *testing.T) {

--- a/index/language-settings_test.go
+++ b/index/language-settings_test.go
@@ -1,7 +1,6 @@
 package index_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/ttab/elephant-index/index"
@@ -37,7 +36,7 @@ func TestGetLanguageSetting(t *testing.T) {
 			t.Fatalf("expected Language: %q, got %q", params[i].language, s.Language)
 		}
 
-		if !strings.Contains(s.Settings, params[i].analyzer) {
+		if s.Settings.Settings.Analysis.Analyzer.Default.Type != params[i].analyzer {
 			t.Fatalf("expected settings default Analyzer: %q, got %q", params[i].analyzer, s.Settings)
 		}
 	}

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 15.3 (Debian 15.3-1.pgdg120+1)
--- Dumped by pg_dump version 15.3 (Debian 15.3-1.pgdg120+1)
+-- Dumped from database version 15.3 (Debian 15.3-1.pgdg110+1)
+-- Dumped by pg_dump version 15.3 (Debian 15.3-1.pgdg110+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/postgres/schema_version.sql
+++ b/postgres/schema_version.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 15.3 (Debian 15.3-1.pgdg120+1)
--- Dumped by pg_dump version 15.3 (Debian 15.3-1.pgdg120+1)
+-- Dumped from database version 15.3 (Debian 15.3-1.pgdg110+1)
+-- Dumped by pg_dump version 15.3 (Debian 15.3-1.pgdg110+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;


### PR DESCRIPTION
Create a separate index for each known language/region, with correct analyzer set for the language. A document in swedish will go into the `documents-v1-core_article-sv-se` index, while a document in finland swedish will go into `documents-v1-core_article-sv-fi`. Both will use the analyzer `swedish`.

Aliases are created on both the language and docType level, so for the above examples both of the indices would also be added to the `documents-v1-core_article-sv` and `documents-v1-core_article` aliases.

We do not (yet) handle the case when documents change language.