### PR TITLE
handle meta documents in the indexer

### DIFF
--- a/index/document.go
+++ b/index/document.go
@@ -16,6 +16,7 @@ type DocumentState struct {
 	ACL            []ACLEntry        `json:"acl"`
 	Heads          map[string]Status `json:"heads"`
 	Document       newsdoc.Document  `json:"document"`
+	MetaDocument   *newsdoc.Document `json:"meta_document"`
 }
 
 type Document struct {

--- a/index/index.go
+++ b/index/index.go
@@ -288,7 +288,7 @@ func (idx *Indexer) loopIteration(
 		// Load document early so that we can pivot to a delete if the
 		// document has been deleted. But only try to fetch it if we
 		// don't already know that it has been deleted.
-		if item.Event != DeleteEvent {
+		if item.Event != DeleteEvent { //nolint: nestif
 			docRes, err := idx.documents.Get(ctx,
 				&repository.GetDocumentRequest{
 					Uuid:         docUUID,


### PR DESCRIPTION
This will prevent the indexer from indexing meta documents as standalone documents and will instead add them under the prefix "meta." on the parent document.

```
          "meta.rel.subject.data.confidence": [
            "0.9333943128585815",
            "0.9994723200798035",
            "0.9996071457862854",
            "0.9996544122695923",
            "0.9996570348739624",
            "0.13343428075313568"
          ],
          "meta.rel.subject.data.status": [
            "automatic"
          ],
          "meta.rel.subject.title": [
            "Kungligt",
            "Indien",
            "Pakistan",
            "Iran",
            "Afghanistan",
            "BBC"
          ],
          "meta.rel.subject.type": [
            "core/category",
            "core/place",
            "core/organisation"
          ],
          "meta.rel.subject.uuid": [
            "527e2c20-c01d-5a50-9874-448210b50286",
            "9af5164f-2ce4-5245-ae63-550d033c042f",
            "20973094-e734-533d-9da8-51ce1a453bf1",
            "d46e75a1-b118-545c-ae69-43979eb90fc0",
            "6bd98ee4-1f28-54c0-820d-f921f9884341",
            "25d4e28b-18f8-40bc-8df8-39b8bb6a5cb4"
          ],
```