### PR TITLE
support document type variants in index naming

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -607,7 +607,7 @@ func NewIndexName(
 	docType string,
 	language LanguageInfo,
 ) IndexName {
-	indexTypeName := internal.NonAlphaNum.ReplaceAllString(docType, "_")
+	indexTypeName := internal.SanitizeDocType(docType)
 	root := fmt.Sprintf("%s-%s-%s", t, setName, indexTypeName)
 	localeSuffix := fmt.Sprintf("%s-%s", language.Language, language.RegionSuffix)
 	languageName := fmt.Sprintf("%s-%s", indexTypeName, localeSuffix)

--- a/index/language-settings_test.go
+++ b/index/language-settings_test.go
@@ -85,4 +85,20 @@ func TestGetLanguageSetting(t *testing.T) {
 				analysis.Analyzer["default"].Type)
 		}
 	}
+
+	t.Run("variant type", func(t *testing.T) {
+		res := index.NewLanguageResolver(index.LanguageOptions{})
+
+		lang, err := res.GetLanguageInfo("sv-SE")
+		test.Must(t, err, "get language info")
+
+		idx := index.NewIndexName(
+			index.IndexTypeDocuments,
+			"happy-hog", "core/article+template", lang)
+
+		test.Equal(t, "core_article--template-sv-se", idx.Language,
+			"variant type language name")
+		test.Equal(t, "documents-happy-hog-core_article--template-sv-se", idx.Full,
+			"variant type full name")
+	})
 }

--- a/index/search_api_test.go
+++ b/index/search_api_test.go
@@ -31,6 +31,11 @@ func TestIndexPattern(t *testing.T) {
 			Language:     "sv-se",
 		}),
 		"index pattern with text and language and region")
+	test.Equal(t, "documents-foo-core_article--template-*",
+		internal.IndexPattern("foo", &index.QueryRequestV1{
+			DocumentType: "core/article+template",
+		}),
+		"index pattern with variant type")
 }
 
 func TestLoadDocumentHasSizeCap(t *testing.T) {

--- a/internal/searchrequest.go
+++ b/internal/searchrequest.go
@@ -16,13 +16,27 @@ const (
 
 var NonAlphaNum = regexp.MustCompile(`[^a-zA-Z0-9 ]+`)
 
+// SanitizeDocType converts a document type name into a string safe for use in
+// index names. The "+" variant separator is replaced with "--" to avoid
+// collisions with the "_" used for other non-alphanumeric characters.
+func SanitizeDocType(docType string) string {
+	base, variant, hasVariant := strings.Cut(docType, "+")
+	sanitized := NonAlphaNum.ReplaceAllString(base, "_")
+
+	if hasVariant {
+		sanitized += "--" + NonAlphaNum.ReplaceAllString(variant, "_")
+	}
+
+	return sanitized
+}
+
 func IndexPattern(
 	indexSet string, req *index.QueryRequestV1,
 ) (indexPattern string) {
 	indexPattern = "documents-" + indexSet
 
 	if req.DocumentType != "" {
-		indexPattern += "-" + NonAlphaNum.ReplaceAllString(req.DocumentType, "_")
+		indexPattern += "-" + SanitizeDocType(req.DocumentType)
 	} else {
 		indexPattern += "-*"
 	}


### PR DESCRIPTION
Document types can now have a "+" variant suffix (e.g. "core/article+template"). Previously, the index name sanitization replaced all non-alphanumeric characters with "_", which meant "core/article+template" and a hypothetical "core/article_template" would both map to the same index name "core_article_template", causing unrelated documents to collide in the same index.

This introduces a SanitizeDocType() function that handles the "+" separator distinctly by using "--" as the variant delimiter in index names:

  core/article           -> core_article          (unchanged)
  core/article+template  -> core_article--template (new, collision-free)

The "--" separator is safe for OpenSearch index names and doesn't appear in existing index names (set names are random codenames, languages use single "-").

Both IndexPattern() (search path) and NewIndexName() (indexing path) now use the shared sanitization function.