### PR TITLE
map fuzziness and prefix_length in multi_match queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0
 	github.com/ory/dockertest/v3 v3.12.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/ttab/elephant-api v0.21.3
+	github.com/ttab/elephant-api v0.21.4-0.20260402085205-bdff2c51f64b
 	github.com/ttab/elephantine v0.25.0
 	github.com/ttab/eltest v0.2.2
 	github.com/ttab/flerr v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0
 	github.com/ory/dockertest/v3 v3.12.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/ttab/elephant-api v0.21.4-0.20260402085205-bdff2c51f64b
+	github.com/ttab/elephant-api v0.22.1
 	github.com/ttab/elephantine v0.25.0
 	github.com/ttab/eltest v0.2.2
 	github.com/ttab/flerr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tinylib/msgp v1.5.0 h1:GWnqAE54wmnlFazjq2+vgr736Akg58iiHImh+kPY2pc=
 github.com/tinylib/msgp v1.5.0/go.mod h1:cvjFkb4RiC8qSBOPMGPSzSAx47nAsfhLVTCZZNuHv5o=
-github.com/ttab/elephant-api v0.21.3 h1:nIz1lc/H/Nio7Dib0zLti76j4Bw1Bj/Nqi4vd81dqws=
-github.com/ttab/elephant-api v0.21.3/go.mod h1:tR17cFbfHfhCFs6O2s13eHU7y5CIechhZIHDEvNJvcU=
+github.com/ttab/elephant-api v0.21.4-0.20260402085205-bdff2c51f64b h1:HTh/kMKvTzqRfznSQTj5+U4/ZbO72dqhXgxJRxLfm+k=
+github.com/ttab/elephant-api v0.21.4-0.20260402085205-bdff2c51f64b/go.mod h1:tR17cFbfHfhCFs6O2s13eHU7y5CIechhZIHDEvNJvcU=
 github.com/ttab/elephantine v0.25.0 h1:0Z9tvlqzVD2rUSwwihOK/iqtjoPO0Xh0JzTCWUSRzMM=
 github.com/ttab/elephantine v0.25.0/go.mod h1:T4ZtP2Clg236YZehCituqPCDFZ2PuBn/BoX5gYkCtvE=
 github.com/ttab/eltest v0.2.2 h1:T9+XZdLQJQciy7U/Q+TZskaxpnwdRJKEtaSz0699H+4=

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tinylib/msgp v1.5.0 h1:GWnqAE54wmnlFazjq2+vgr736Akg58iiHImh+kPY2pc=
 github.com/tinylib/msgp v1.5.0/go.mod h1:cvjFkb4RiC8qSBOPMGPSzSAx47nAsfhLVTCZZNuHv5o=
-github.com/ttab/elephant-api v0.21.4-0.20260402085205-bdff2c51f64b h1:HTh/kMKvTzqRfznSQTj5+U4/ZbO72dqhXgxJRxLfm+k=
-github.com/ttab/elephant-api v0.21.4-0.20260402085205-bdff2c51f64b/go.mod h1:tR17cFbfHfhCFs6O2s13eHU7y5CIechhZIHDEvNJvcU=
+github.com/ttab/elephant-api v0.22.1 h1:XJCFLVpt99rQpLkNJhPLQL2fFpUZPQu8i8VfIE9K8do=
+github.com/ttab/elephant-api v0.22.1/go.mod h1:tR17cFbfHfhCFs6O2s13eHU7y5CIechhZIHDEvNJvcU=
 github.com/ttab/elephantine v0.25.0 h1:0Z9tvlqzVD2rUSwwihOK/iqtjoPO0Xh0JzTCWUSRzMM=
 github.com/ttab/elephantine v0.25.0/go.mod h1:T4ZtP2Clg236YZehCituqPCDFZ2PuBn/BoX5gYkCtvE=
 github.com/ttab/eltest v0.2.2 h1:T9+XZdLQJQciy7U/Q+TZskaxpnwdRJKEtaSz0699H+4=

--- a/index/multi_match_test.go
+++ b/index/multi_match_test.go
@@ -106,6 +106,103 @@ func TestMultiMatchFuzzinessWithPrefixLength(t *testing.T) {
 	)
 }
 
+func TestMultiMatchFuzzinessAuto(t *testing.T) {
+	req, err := internal.NewSearchRequest(
+		&elephantine.AuthInfo{
+			Claims: elephantine.JWTClaims{
+				RegisteredClaims: jwt.RegisteredClaims{
+					Subject: "core://user/1",
+				},
+				Scope: "doc_admin",
+			},
+		},
+		&index.QueryRequestV1{
+			Query: &index.QueryV1{
+				Conditions: &index.QueryV1_MultiMatch{
+					MultiMatch: &index.MultiMatchQueryV1{
+						Fields: []string{"document.title"},
+						Query:  "ukrane",
+						Type:   "best_fields",
+						Fuzziness: &index.Fuzziness{
+							Auto: &index.FuzzinessAuto{},
+						},
+					},
+				},
+			},
+		},
+	)
+	test.Must(t, err, "multi_match with fuzziness AUTO")
+	test.Equal(t,
+		&internal.SearchRequestV1{
+			Size: internal.DefaultSearchSize,
+			Query: map[string]any{
+				"bool": internal.BoolConditionsV1{
+					Must: []map[string]any{{
+						"multi_match": map[string]any{
+							"fields":    []string{"document.title"},
+							"query":     "ukrane",
+							"type":      "best_fields",
+							"fuzziness": "AUTO",
+						},
+					}},
+				},
+			},
+		},
+		req,
+		"multi_match with fuzziness AUTO",
+	)
+}
+
+func TestMultiMatchFuzzinessAutoCustom(t *testing.T) {
+	req, err := internal.NewSearchRequest(
+		&elephantine.AuthInfo{
+			Claims: elephantine.JWTClaims{
+				RegisteredClaims: jwt.RegisteredClaims{
+					Subject: "core://user/1",
+				},
+				Scope: "doc_admin",
+			},
+		},
+		&index.QueryRequestV1{
+			Query: &index.QueryV1{
+				Conditions: &index.QueryV1_MultiMatch{
+					MultiMatch: &index.MultiMatchQueryV1{
+						Fields: []string{"document.title"},
+						Query:  "ukrane",
+						Type:   "best_fields",
+						Fuzziness: &index.Fuzziness{
+							Auto: &index.FuzzinessAuto{
+								Low:  4,
+								High: 8,
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	test.Must(t, err, "multi_match with fuzziness AUTO:4,8")
+	test.Equal(t,
+		&internal.SearchRequestV1{
+			Size: internal.DefaultSearchSize,
+			Query: map[string]any{
+				"bool": internal.BoolConditionsV1{
+					Must: []map[string]any{{
+						"multi_match": map[string]any{
+							"fields":    []string{"document.title"},
+							"query":     "ukrane",
+							"type":      "best_fields",
+							"fuzziness": "AUTO:4,8",
+						},
+					}},
+				},
+			},
+		},
+		req,
+		"multi_match with fuzziness AUTO:4,8",
+	)
+}
+
 func TestMultiMatchWithoutFuzziness(t *testing.T) {
 	req, err := internal.NewSearchRequest(
 		&elephantine.AuthInfo{

--- a/index/multi_match_test.go
+++ b/index/multi_match_test.go
@@ -1,0 +1,150 @@
+package index_test
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/ttab/elephant-api/index"
+	"github.com/ttab/elephant-index/internal"
+	"github.com/ttab/elephantine"
+	"github.com/ttab/elephantine/test"
+)
+
+func TestMultiMatchFuzziness(t *testing.T) {
+	req, err := internal.NewSearchRequest(
+		&elephantine.AuthInfo{
+			Claims: elephantine.JWTClaims{
+				RegisteredClaims: jwt.RegisteredClaims{
+					Subject: "core://user/1",
+				},
+				Scope: "doc_admin",
+			},
+		},
+		&index.QueryRequestV1{
+			Query: &index.QueryV1{
+				Conditions: &index.QueryV1_MultiMatch{
+					MultiMatch: &index.MultiMatchQueryV1{
+						Fields: []string{"document.title"},
+						Query:  "ukrane",
+						Type:   "best_fields",
+						Fuzziness: &index.Fuzziness{
+							Edits: 2,
+						},
+					},
+				},
+			},
+		},
+	)
+	test.Must(t, err, "multi_match with fuzziness")
+	test.Equal(t,
+		&internal.SearchRequestV1{
+			Size: internal.DefaultSearchSize,
+			Query: map[string]any{
+				"bool": internal.BoolConditionsV1{
+					Must: []map[string]any{{
+						"multi_match": map[string]any{
+							"fields":    []string{"document.title"},
+							"query":     "ukrane",
+							"type":      "best_fields",
+							"fuzziness": int64(2),
+						},
+					}},
+				},
+			},
+		},
+		req,
+		"multi_match with fuzziness",
+	)
+}
+
+func TestMultiMatchFuzzinessWithPrefixLength(t *testing.T) {
+	req, err := internal.NewSearchRequest(
+		&elephantine.AuthInfo{
+			Claims: elephantine.JWTClaims{
+				RegisteredClaims: jwt.RegisteredClaims{
+					Subject: "core://user/1",
+				},
+				Scope: "doc_admin",
+			},
+		},
+		&index.QueryRequestV1{
+			Query: &index.QueryV1{
+				Conditions: &index.QueryV1_MultiMatch{
+					MultiMatch: &index.MultiMatchQueryV1{
+						Fields: []string{"document.title", "document.content"},
+						Query:  "ukrane",
+						Type:   "best_fields",
+						Fuzziness: &index.Fuzziness{
+							Edits: 1,
+						},
+						PrefixLength: 2,
+					},
+				},
+			},
+		},
+	)
+	test.Must(t, err, "multi_match with fuzziness and prefix_length")
+	test.Equal(t,
+		&internal.SearchRequestV1{
+			Size: internal.DefaultSearchSize,
+			Query: map[string]any{
+				"bool": internal.BoolConditionsV1{
+					Must: []map[string]any{{
+						"multi_match": map[string]any{
+							"fields":        []string{"document.title", "document.content"},
+							"query":         "ukrane",
+							"type":          "best_fields",
+							"fuzziness":     int64(1),
+							"prefix_length": int64(2),
+						},
+					}},
+				},
+			},
+		},
+		req,
+		"multi_match with fuzziness and prefix_length",
+	)
+}
+
+func TestMultiMatchWithoutFuzziness(t *testing.T) {
+	req, err := internal.NewSearchRequest(
+		&elephantine.AuthInfo{
+			Claims: elephantine.JWTClaims{
+				RegisteredClaims: jwt.RegisteredClaims{
+					Subject: "core://user/1",
+				},
+				Scope: "doc_admin",
+			},
+		},
+		&index.QueryRequestV1{
+			Query: &index.QueryV1{
+				Conditions: &index.QueryV1_MultiMatch{
+					MultiMatch: &index.MultiMatchQueryV1{
+						Fields: []string{"document.title"},
+						Query:  "ukraine",
+						Type:   "best_fields",
+					},
+				},
+			},
+		},
+	)
+	test.Must(t, err, "multi_match without fuzziness")
+	test.Equal(t,
+		&internal.SearchRequestV1{
+			Size: internal.DefaultSearchSize,
+			Query: map[string]any{
+				"bool": internal.BoolConditionsV1{
+					Must: []map[string]any{{
+						"multi_match": map[string]any{
+							"fields": []string{"document.title"},
+							"query":  "ukraine",
+							"type":   "best_fields",
+						},
+					}},
+				},
+			},
+		},
+		req,
+		"multi_match without fuzziness",
+	)
+}

--- a/internal/searchrequest.go
+++ b/internal/searchrequest.go
@@ -338,7 +338,7 @@ func multiMatchQueryV1(q *index.MultiMatchQueryV1) map[string]any {
 	}
 
 	if q.Fuzziness != nil {
-		spec["fuzziness"] = q.Fuzziness.Edits
+		spec["fuzziness"] = fuzzinessValue(q.Fuzziness)
 	}
 
 	if q.PrefixLength != 0 {
@@ -388,6 +388,18 @@ func prefixQueryV1(
 	return QWrap("prefix", map[string]any{
 		field: spec,
 	})
+}
+
+func fuzzinessValue(f *index.Fuzziness) any {
+	if f.Auto == nil {
+		return f.Edits
+	}
+
+	if f.Auto.Low != 0 || f.Auto.High != 0 {
+		return fmt.Sprintf("AUTO:%d,%d", f.Auto.Low, f.Auto.High)
+	}
+
+	return "AUTO"
 }
 
 func addBoostCase(

--- a/internal/searchrequest.go
+++ b/internal/searchrequest.go
@@ -337,6 +337,14 @@ func multiMatchQueryV1(q *index.MultiMatchQueryV1) map[string]any {
 		spec["tie_breaker"] = q.TieBreaker
 	}
 
+	if q.Fuzziness != nil {
+		spec["fuzziness"] = q.Fuzziness.Edits
+	}
+
+	if q.PrefixLength != 0 {
+		spec["prefix_length"] = q.PrefixLength
+	}
+
 	return QWrap("multi_match", spec)
 }
 


### PR DESCRIPTION
The MultiMatchQueryV1 protobuf had fuzziness and prefix_length fields that were not being translated to the OpenSearch multi_match query, causing fuzzy searches from the client to silently fall back to exact matching.